### PR TITLE
Remove Tungus and TingoDB

### DIFF
--- a/lib/gulp-mocha.js
+++ b/lib/gulp-mocha.js
@@ -1,7 +1,5 @@
 'use strict';
 
-require('./utils/tungus.js');
-
 var gulp = require('gulp');
 var mocha = require('gulp-mocha');
 var del = require('del');

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "gulp-mocha": "1.1.1",
     "gulp-nodemon": "1.0.4",
     "jshint-stylish": "1.0.0",
-    "mocha": "1.21.5",
-    "tungus": "0.0.3"
+    "mocha": "1.21.5"
   }
 }


### PR DESCRIPTION
Removing Tungus because it doesn't support Model.update(..) with dot notation in query